### PR TITLE
add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Media captions parser and renderer.",
   "license": "MIT",
   "type": "module",
+  "main": "./dist/prod.js",
   "types": "dist/types/index.d.ts",
   "sideEffects": false,
   "jsdelivr": "./dist/prod.js",


### PR DESCRIPTION
In webpack 4, we can't use this library because it doesn't understand the `exports` field in the `package.json` file. We can solve that by adding a `main` field to `package.json`.